### PR TITLE
🤖 Github Action -- 11 -> 17

### DIFF
--- a/.github/workflows/gradle-build-deploy.yml
+++ b/.github/workflows/gradle-build-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: adopt
       - name: Gradle Build
         run: ./gradlew build test site


### PR DESCRIPTION
### What
11 -> 17 Java version

### Why
it didnt blow 


### How
17 > 11

### Testing
Other repo didn't explode. 

### Additional Notes
Turns out 102-assignments repo was already on 17
