### PR TITLE
:technologist: `Heap` class

### DIFF
--- a/src/main/java/Heap.java
+++ b/src/main/java/Heap.java
@@ -54,19 +54,18 @@ public class Heap<T> {
     }
 
     private void bubbleDown(int index) {
-        int largerChild = index;
+        int swapChild = index;
         int leftChild = getLeft(index);
         int rightChild = getRight(index);
-        int comparison = comparator.compare(heap[largerChild], heap[leftChild]);
-        if (leftChild < size() && comparison > 0) {
-            largerChild = leftChild;
+        if (leftChild < size() && comparator.compare(heap[swapChild], heap[leftChild]) > 0) {
+            swapChild = leftChild;
         }
-        if (rightChild < size() && comparison > 0) {
-            largerChild = rightChild;
+        if (rightChild < size() && comparator.compare(heap[swapChild], heap[rightChild]) > 0) {
+            swapChild = rightChild;
         }
-        if (largerChild != index) {
-            swap(index, largerChild);
-            bubbleDown(largerChild);
+        if (swapChild != index) {
+            swap(index, swapChild);
+            bubbleDown(swapChild);
         }
     }
 

--- a/src/main/java/Heap.java
+++ b/src/main/java/Heap.java
@@ -1,6 +1,7 @@
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 /**
  * A heap with the ordering defined by either the natural ordering of the elements within the heap or by a
@@ -164,5 +165,26 @@ public class Heap<T> {
         }
         stringBuilder.append("]");
         return stringBuilder.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Heap<?> that = (Heap<?>) o;
+        return Arrays.equals(this.heap, 0, this.size(), that.heap, 0, that.size());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(size);
+        for (int i = 0; i < size(); i++) {
+            result = result * 97 + Objects.hashCode(heap[i]);
+        }
+        return result;
     }
 }

--- a/src/main/java/Heap.java
+++ b/src/main/java/Heap.java
@@ -1,3 +1,5 @@
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.NoSuchElementException;
 
 /**
@@ -6,14 +8,84 @@ import java.util.NoSuchElementException;
  * defined by the ordering.
  * <p>
  * If no Comparator is provided to the constructor, the heap will order the elements based on the natural ordering of
- * the elements. This means that the elements within the heap must be comparable. If a Comparator is provided, the
- * elements do not need to be comparable as the elements are ordered based on the Comparator, regardless of the
- * natural ordering of the elements that may exist.
+ * the elements. This means that the elements within the heap must be comparable, otherwise adding to the heap will
+ * cause a ClassCastException to be thrown. If a Comparator is provided, the elements do not need to be comparable as
+ * the elements are ordered based on the Comparator, regardless of the natural ordering of the elements that may exist.
  *
  * @param <T> Type of elements that are to be in the heap. If a comparator is not provided, then T must be comparable
- *            in order to use the natural ordering of the elements.
+ *            in order to use the natural ordering of the elements, otherwise a ClassCastException is thrown when
+ *            adding.
  */
 public class Heap<T> {
+
+    private static final int DEFAULT_CAPACITY = 100;
+
+    private int size;
+    private T[] heap;
+    private Comparator<T> comparator;
+
+    /**
+     * Create a heap with a natural order comparator defining the ordering of the elements..
+     */
+    public Heap() {
+        this((Comparator<T>) Comparator.naturalOrder());
+    }
+
+    /**
+     * Create a heap with the specified comparator defining the ordering of the elements.
+     *
+     * @param comparator Comparator defining the order of the elements in the heap
+     */
+    public Heap(Comparator<T> comparator) {
+        size = 0;
+        heap = (T[]) new Object[DEFAULT_CAPACITY];
+        this.comparator = comparator;
+    }
+
+    private void bubbleUp(int index) {
+        int currentIndex = index;
+        int parentIndex = getParent(size);
+        while (currentIndex != 0 && comparator.compare(heap[currentIndex], heap[parentIndex]) < 0) {
+            swap(currentIndex, parentIndex);
+            currentIndex = parentIndex;
+            parentIndex = getParent(currentIndex);
+        }
+    }
+
+    private void bubbleDown(int index) {
+        int largerChild = index;
+        int leftChild = getLeft(index);
+        int rightChild = getRight(index);
+        int comparison = comparator.compare(heap[largerChild], heap[leftChild]);
+        if (leftChild < size() && comparison > 0) {
+            largerChild = leftChild;
+        }
+        if (rightChild < size() && comparison > 0) {
+            largerChild = rightChild;
+        }
+        if (largerChild != index) {
+            swap(index, largerChild);
+            bubbleDown(largerChild);
+        }
+    }
+
+    private void swap(int currentIndex, int parentIndex) {
+        T temp = heap[parentIndex];
+        heap[parentIndex] = heap[currentIndex];
+        heap[currentIndex] = temp;
+    }
+
+    private int getParent(int index) {
+        return (index - 1) / 2;
+    }
+
+    private int getLeft(int index) {
+        return 2 * index + 1;
+    }
+
+    private int getRight(int index) {
+        return 2 * index + 2;
+    }
 
     /**
      * Add the provided element to the heap.
@@ -22,7 +94,13 @@ public class Heap<T> {
      * @return true if the element was added successfully, false otherwise
      */
     boolean add(T element) {
-        return false;
+        if (size() == heap.length) {
+            heap = Arrays.copyOf(heap, heap.length * 2);
+        }
+        heap[size] = element;
+        bubbleUp(size);
+        size++;
+        return true;
     }
 
     /**
@@ -32,7 +110,15 @@ public class Heap<T> {
      * @throws NoSuchElementException If the heap is empty
      */
     T remove() {
-        return null;
+        if (isEmpty()) {
+            throw new NoSuchElementException("Empty Heap");
+        }
+        T toReturn = heap[0];
+        heap[0] = heap[size - 1];
+        heap[size - 1] = null;
+        size--;
+        bubbleDown(0);
+        return toReturn;
     }
 
     /**
@@ -42,7 +128,10 @@ public class Heap<T> {
      * @throws NoSuchElementException If the heap is empty
      */
     T peek() {
-        return null;
+        if (isEmpty()) {
+            throw new NoSuchElementException("Empty Heap");
+        }
+        return heap[0];
     }
 
     /**
@@ -51,7 +140,7 @@ public class Heap<T> {
      * @return true if the heap is empty, false otherwise
      */
     boolean isEmpty() {
-        return false;
+        return size() == 0;
     }
 
     /**
@@ -60,6 +149,6 @@ public class Heap<T> {
      * @return Number of elements within the heap
      */
     int size() {
-        return 0;
+        return size;
     }
 }

--- a/src/main/java/Heap.java
+++ b/src/main/java/Heap.java
@@ -151,4 +151,18 @@ public class Heap<T> {
     int size() {
         return size;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("[");
+        for (int i = 0; i < size(); i++) {
+            stringBuilder.append(heap[i]);
+            if (i < size() - 1) {
+                stringBuilder.append(", ");
+            }
+        }
+        stringBuilder.append("]");
+        return stringBuilder.toString();
+    }
 }

--- a/src/test/java/HeapTest.java
+++ b/src/test/java/HeapTest.java
@@ -1,0 +1,104 @@
+import com.google.common.testing.EqualsTester;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Comparator;
+
+class HeapTest {
+
+    private Heap<Integer> classUnderTest;
+    private Heap<Integer> preState;
+
+    @Test
+    @SuppressWarnings("UnstableApiUsage")
+    public void equals_verify_contract() {
+        Heap<Integer> emptyA = new Heap<>();
+        Heap<Integer> emptyB = new Heap<>();
+        Heap<Integer> emptyComparator = new Heap<>((Comparator<Integer>) Comparator.naturalOrder());
+
+        Heap<Integer> singletonA = new Heap<>();
+        Heap<Integer> singletonB = new Heap<>();
+        Heap<Integer> singletonComparator = new Heap<>((Comparator<Integer>) Comparator.naturalOrder());
+        singletonA.add(10);
+        singletonB.add(10);
+        singletonComparator.add(10);
+
+        Heap<Integer> manyA = new Heap<>();
+        Heap<Integer> manyB = new Heap<>();
+        Heap<Integer> manyComparator = new Heap<>((Comparator<Integer>) Comparator.naturalOrder());
+        manyA.add(10);
+        manyA.add(20);
+        manyA.add(10);
+        manyA.add(5);
+        manyA.add(15);
+        manyB.add(10);
+        manyB.add(20);
+        manyB.add(10);
+        manyB.add(5);
+        manyB.add(15);
+        manyComparator.add(10);
+        manyComparator.add(20);
+        manyComparator.add(10);
+        manyComparator.add(5);
+        manyComparator.add(15);
+
+        Heap<Integer> unequalDifferentValues = new Heap<>();
+        unequalDifferentValues.add(100);
+        unequalDifferentValues.add(200);
+        unequalDifferentValues.add(100);
+        unequalDifferentValues.add(50);
+        unequalDifferentValues.add(150);
+
+        Heap<Integer> unequalDifferentOrder = new Heap<>();
+        unequalDifferentOrder.add(5);
+        unequalDifferentOrder.add(10);
+        unequalDifferentOrder.add(10);
+        unequalDifferentOrder.add(15);
+        unequalDifferentOrder.add(20);
+
+        Heap<Integer> unequalDifferentSizes = new Heap<>();
+        unequalDifferentSizes.add(10);
+        unequalDifferentSizes.add(20);
+        unequalDifferentSizes.add(10);
+        unequalDifferentSizes.add(5);
+
+        Heap<Integer> unequalSomeEqual = new Heap<>();
+        unequalSomeEqual.add(10);
+        unequalSomeEqual.add(20);
+        unequalSomeEqual.add(10);
+        unequalSomeEqual.add(5);
+        unequalSomeEqual.add(20);
+
+        Heap<Integer> unequalDifferentComparator = new Heap<>((Comparator<Integer>) Comparator.naturalOrder()
+                .reversed());
+        unequalDifferentComparator.add(10);
+        unequalDifferentComparator.add(20);
+        unequalDifferentComparator.add(10);
+        unequalDifferentComparator.add(5);
+        unequalDifferentComparator.add(15);
+
+        new EqualsTester().addEqualityGroup(Heap.class)
+                .addEqualityGroup(emptyA, emptyB, emptyComparator)
+                .addEqualityGroup(singletonA, singletonB, singletonComparator)
+                .addEqualityGroup(manyA, manyB, manyComparator)
+                .addEqualityGroup(unequalDifferentValues)
+                .addEqualityGroup(unequalDifferentOrder)
+                .addEqualityGroup(unequalDifferentSizes)
+                .addEqualityGroup(unequalSomeEqual)
+                .addEqualityGroup(unequalDifferentComparator)
+                .testEquals();
+    }
+
+    @BeforeEach
+    void createClassUnderTest() {
+        classUnderTest = new Heap<>();
+        preState = new Heap<>();
+    }
+
+    @Nested
+    class WhenEmpty {
+
+
+    }
+}

--- a/src/test/java/HeapTest.java
+++ b/src/test/java/HeapTest.java
@@ -131,6 +131,11 @@ class HeapTest {
             assertThat(classUnderTest.isEmpty()).isTrue();
         }
 
+        @Test
+        void toString_empty_returnsString() {
+            assertThat(classUnderTest.toString()).isEqualTo("[]");
+        }
+
         @Nested
         class WhenSingleton {
 
@@ -175,6 +180,11 @@ class HeapTest {
             @Test
             void isEmpty_singleton_returnsFalse() {
                 assertThat(classUnderTest.isEmpty()).isFalse();
+            }
+
+            @Test
+            void toString_singleton_returnsString() {
+                assertThat(classUnderTest.toString()).isEqualTo("[10]");
             }
 
             @Nested

--- a/src/test/java/HeapTest.java
+++ b/src/test/java/HeapTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.awt.*;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
 
@@ -15,11 +16,9 @@ class HeapTest {
     private Heap<Integer> classUnderTest;
     private Heap<Integer> preState;
 
-    // TODO --- Tests for non comparable types!?
-
     @Test
     @SuppressWarnings("UnstableApiUsage")
-    public void equals_verify_contract() {
+    void equals_verify_contract() {
         Heap<Integer> emptyA = new Heap<>();
         Heap<Integer> emptyB = new Heap<>();
         Heap<Integer> emptyComparator = new Heap<>((Comparator<Integer>) Comparator.naturalOrder());
@@ -95,6 +94,14 @@ class HeapTest {
                 .addEqualityGroup(unequalSomeEqual)
                 .addEqualityGroup(unequalDifferentComparator)
                 .testEquals();
+    }
+
+
+    @Test
+    void add_nonComparableType_throwsClassCastException() {
+        Heap<Color> trouble = new Heap<>();
+        trouble.add(new Color(0));
+        assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> trouble.add(new Color(0)));
     }
 
     @Nested

--- a/src/test/java/HeapTest.java
+++ b/src/test/java/HeapTest.java
@@ -15,6 +15,8 @@ class HeapTest {
     private Heap<Integer> classUnderTest;
     private Heap<Integer> preState;
 
+    // TODO --- Tests for non comparable types!?
+
     @Test
     @SuppressWarnings("UnstableApiUsage")
     public void equals_verify_contract() {
@@ -106,7 +108,7 @@ class HeapTest {
 
         @Test
         void add_empty_returnsTrue() {
-            assertThat(classUnderTest.add(20)).isTrue();
+            assertThat(classUnderTest.add(99)).isTrue();
         }
 
         @Test
@@ -136,6 +138,43 @@ class HeapTest {
             void addSingleton() {
                 classUnderTest.add(10);
                 preState.add(10);
+            }
+
+            @Test
+            void add_singleton_returnsTrue() {
+                assertThat(classUnderTest.add(99)).isTrue();
+            }
+
+            @Test
+            void remove_singleton_returnsElement() {
+                assertThat(classUnderTest.remove()).isEqualTo(10);
+            }
+
+            @Test
+            void remove_singleton_emptyHeap() {
+                classUnderTest.remove();
+                assertThat(classUnderTest).isEqualTo(new Heap<>());
+            }
+
+            @Test
+            void peek_singleton_returnsElement() {
+                assertThat(classUnderTest.peek()).isEqualTo(10);
+            }
+
+            @Test
+            void peek_singleton_unchanged() {
+                classUnderTest.peek();
+                assertThat(classUnderTest).isEqualTo(preState);
+            }
+
+            @Test
+            void size_singleton_returnsSzie() {
+                assertThat(classUnderTest.size()).isEqualTo(1);
+            }
+
+            @Test
+            void isEmpty_singleton_returnsFalse() {
+                assertThat(classUnderTest.isEmpty()).isFalse();
             }
 
             @Nested

--- a/src/test/java/HeapTest.java
+++ b/src/test/java/HeapTest.java
@@ -97,160 +97,328 @@ class HeapTest {
                 .testEquals();
     }
 
-    @BeforeEach
-    void createClassUnderTest() {
-        classUnderTest = new Heap<>();
-        preState = new Heap<>();
-    }
-
     @Nested
-    class WhenEmpty {
+    class DefaultConstructor {
 
-        @Test
-        void add_empty_returnsTrue() {
-            assertThat(classUnderTest.add(99)).isTrue();
-        }
-
-        @Test
-        void remove_empty_throwsNoSuchElementException() {
-            assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(classUnderTest::remove);
-        }
-
-        @Test
-        void peek_empty_throwsNoSuchElementException() {
-            assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(classUnderTest::peek);
-        }
-
-        @Test
-        void size_empty_returnsZero() {
-            assertThat(classUnderTest.size()).isEqualTo(0);
-        }
-
-        @Test
-        void isEmpty_empty_returnsTrue() {
-            assertThat(classUnderTest.isEmpty()).isTrue();
-        }
-
-        @Test
-        void toString_empty_returnsString() {
-            assertThat(classUnderTest.toString()).isEqualTo("[]");
+        @BeforeEach
+        void createClassUnderTest() {
+            classUnderTest = new Heap<>();
+            preState = new Heap<>();
         }
 
         @Nested
-        class WhenSingleton {
-
-            @BeforeEach
-            void addSingleton() {
-                classUnderTest.add(10);
-                preState.add(10);
-            }
+        class WhenEmpty {
 
             @Test
-            void add_singleton_returnsTrue() {
+            void add_empty_returnsTrue() {
                 assertThat(classUnderTest.add(99)).isTrue();
             }
 
             @Test
-            void remove_singleton_returnsElement() {
-                assertThat(classUnderTest.remove()).isEqualTo(10);
+            void remove_empty_throwsNoSuchElementException() {
+                assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(classUnderTest::remove);
             }
 
             @Test
-            void remove_singleton_emptyHeap() {
-                classUnderTest.remove();
-                assertThat(classUnderTest).isEqualTo(new Heap<>());
+            void peek_empty_throwsNoSuchElementException() {
+                assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(classUnderTest::peek);
             }
 
             @Test
-            void peek_singleton_returnsElement() {
-                assertThat(classUnderTest.peek()).isEqualTo(10);
+            void size_empty_returnsZero() {
+                assertThat(classUnderTest.size()).isEqualTo(0);
             }
 
             @Test
-            void peek_singleton_unchanged() {
-                classUnderTest.peek();
-                assertThat(classUnderTest).isEqualTo(preState);
+            void isEmpty_empty_returnsTrue() {
+                assertThat(classUnderTest.isEmpty()).isTrue();
             }
 
             @Test
-            void size_singleton_returnsSize() {
-                assertThat(classUnderTest.size()).isEqualTo(1);
-            }
-
-            @Test
-            void isEmpty_singleton_returnsFalse() {
-                assertThat(classUnderTest.isEmpty()).isFalse();
-            }
-
-            @Test
-            void toString_singleton_returnsString() {
-                assertThat(classUnderTest.toString()).isEqualTo("[10]");
+            void toString_empty_returnsString() {
+                assertThat(classUnderTest.toString()).isEqualTo("[]");
             }
 
             @Nested
-            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-            class WhenMany {
+            class WhenSingleton {
 
                 @BeforeEach
-                void addMany() {
-                    classUnderTest.add(20);
-                    classUnderTest.add(20);
+                void addSingleton() {
                     classUnderTest.add(10);
-                    classUnderTest.add(5);
-                    classUnderTest.add(15);
-                    preState.add(20);
-                    preState.add(20);
                     preState.add(10);
-                    preState.add(5);
-                    preState.add(15);
                 }
 
                 @Test
-                void add_many_returnsTrue() {
+                void add_singleton_returnsTrue() {
                     assertThat(classUnderTest.add(99)).isTrue();
                 }
 
                 @Test
-                void remove_many_returnsElement() {
-                    assertThat(classUnderTest.remove()).isEqualTo(5);
+                void remove_singleton_returnsElement() {
+                    assertThat(classUnderTest.remove()).isEqualTo(10);
                 }
 
                 @Test
-                void remove_many_change() {
-                    Heap<Integer> expected = new Heap<>();
-                    expected.add(10);
-                    expected.add(10);
-                    expected.add(15);
-                    expected.add(20);
-                    expected.add(20);
+                void remove_singleton_emptyHeap() {
                     classUnderTest.remove();
-                    assertThat(classUnderTest).isEqualTo(expected);
+                    assertThat(classUnderTest).isEqualTo(new Heap<>());
                 }
 
                 @Test
-                void peek_many_returnsElement() {
-                    assertThat(classUnderTest.peek()).isEqualTo(5);
+                void peek_singleton_returnsElement() {
+                    assertThat(classUnderTest.peek()).isEqualTo(10);
                 }
 
                 @Test
-                void peek_many_unchanged() {
+                void peek_singleton_unchanged() {
                     classUnderTest.peek();
                     assertThat(classUnderTest).isEqualTo(preState);
                 }
 
                 @Test
-                void size_many_returnsSize() {
-                    assertThat(classUnderTest.size()).isEqualTo(6);
+                void size_singleton_returnsSize() {
+                    assertThat(classUnderTest.size()).isEqualTo(1);
                 }
 
                 @Test
-                void isEmpty_many_returnsFalse() {
+                void isEmpty_singleton_returnsFalse() {
                     assertThat(classUnderTest.isEmpty()).isFalse();
                 }
 
                 @Test
-                void toString_many_returnsString() {
-                    assertThat(classUnderTest.toString()).isEqualTo("[5, 10, 15, 20, 10, 20]");
+                void toString_singleton_returnsString() {
+                    assertThat(classUnderTest.toString()).isEqualTo("[10]");
+                }
+
+                @Nested
+                @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+                class WhenMany {
+
+                    @BeforeEach
+                    void addMany() {
+                        classUnderTest.add(20);
+                        classUnderTest.add(20);
+                        classUnderTest.add(10);
+                        classUnderTest.add(5);
+                        classUnderTest.add(15);
+                        preState.add(20);
+                        preState.add(20);
+                        preState.add(10);
+                        preState.add(5);
+                        preState.add(15);
+                    }
+
+                    @Test
+                    void add_many_returnsTrue() {
+                        assertThat(classUnderTest.add(99)).isTrue();
+                    }
+
+                    @Test
+                    void remove_many_returnsElement() {
+                        assertThat(classUnderTest.remove()).isEqualTo(5);
+                    }
+
+                    @Test
+                    void remove_many_change() {
+                        Heap<Integer> expected = new Heap<>();
+                        expected.add(10);
+                        expected.add(10);
+                        expected.add(15);
+                        expected.add(20);
+                        expected.add(20);
+                        classUnderTest.remove();
+                        assertThat(classUnderTest).isEqualTo(expected);
+                    }
+
+                    @Test
+                    void peek_many_returnsElement() {
+                        assertThat(classUnderTest.peek()).isEqualTo(5);
+                    }
+
+                    @Test
+                    void peek_many_unchanged() {
+                        classUnderTest.peek();
+                        assertThat(classUnderTest).isEqualTo(preState);
+                    }
+
+                    @Test
+                    void size_many_returnsSize() {
+                        assertThat(classUnderTest.size()).isEqualTo(6);
+                    }
+
+                    @Test
+                    void isEmpty_many_returnsFalse() {
+                        assertThat(classUnderTest.isEmpty()).isFalse();
+                    }
+
+                    @Test
+                    void toString_many_returnsString() {
+                        assertThat(classUnderTest.toString()).isEqualTo("[5, 10, 15, 20, 10, 20]");
+                    }
+                }
+            }
+        }
+    }
+
+    @Nested
+    class ComparatorConstructor {
+
+        @BeforeEach
+        void createClassUnderTest() {
+            classUnderTest = new Heap<>((Comparator<Integer>) Comparator.naturalOrder().reversed());
+            preState = new Heap<>((Comparator<Integer>) Comparator.naturalOrder().reversed());
+        }
+
+        @Nested
+        class WhenEmpty {
+
+            @Test
+            void add_empty_returnsTrue() {
+                assertThat(classUnderTest.add(99)).isTrue();
+            }
+
+            @Test
+            void remove_empty_throwsNoSuchElementException() {
+                assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(classUnderTest::remove);
+            }
+
+            @Test
+            void peek_empty_throwsNoSuchElementException() {
+                assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(classUnderTest::peek);
+            }
+
+            @Test
+            void size_empty_returnsZero() {
+                assertThat(classUnderTest.size()).isEqualTo(0);
+            }
+
+            @Test
+            void isEmpty_empty_returnsTrue() {
+                assertThat(classUnderTest.isEmpty()).isTrue();
+            }
+
+            @Test
+            void toString_empty_returnsString() {
+                assertThat(classUnderTest.toString()).isEqualTo("[]");
+            }
+
+            @Nested
+            class WhenSingleton {
+
+                @BeforeEach
+                void addSingleton() {
+                    classUnderTest.add(10);
+                    preState.add(10);
+                }
+
+                @Test
+                void add_singleton_returnsTrue() {
+                    assertThat(classUnderTest.add(99)).isTrue();
+                }
+
+                @Test
+                void remove_singleton_returnsElement() {
+                    assertThat(classUnderTest.remove()).isEqualTo(10);
+                }
+
+                @Test
+                void remove_singleton_emptyHeap() {
+                    classUnderTest.remove();
+                    assertThat(classUnderTest).isEqualTo(new Heap<>((Comparator<Integer>) Comparator.naturalOrder()
+                            .reversed()));
+                }
+
+                @Test
+                void peek_singleton_returnsElement() {
+                    assertThat(classUnderTest.peek()).isEqualTo(10);
+                }
+
+                @Test
+                void peek_singleton_unchanged() {
+                    classUnderTest.peek();
+                    assertThat(classUnderTest).isEqualTo(preState);
+                }
+
+                @Test
+                void size_singleton_returnsSize() {
+                    assertThat(classUnderTest.size()).isEqualTo(1);
+                }
+
+                @Test
+                void isEmpty_singleton_returnsFalse() {
+                    assertThat(classUnderTest.isEmpty()).isFalse();
+                }
+
+                @Test
+                void toString_singleton_returnsString() {
+                    assertThat(classUnderTest.toString()).isEqualTo("[10]");
+                }
+
+                @Nested
+                @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+                class WhenMany {
+
+                    @BeforeEach
+                    void addMany() {
+                        classUnderTest.add(20);
+                        classUnderTest.add(20);
+                        classUnderTest.add(10);
+                        classUnderTest.add(5);
+                        classUnderTest.add(15);
+                        preState.add(20);
+                        preState.add(20);
+                        preState.add(10);
+                        preState.add(5);
+                        preState.add(15);
+                    }
+
+                    @Test
+                    void add_many_returnsTrue() {
+                        assertThat(classUnderTest.add(99)).isTrue();
+                    }
+
+                    @Test
+                    void remove_many_returnsElement() {
+                        assertThat(classUnderTest.remove()).isEqualTo(20);
+                    }
+
+                    @Test
+                    void remove_many_change() {
+                        Heap<Integer> expected = new Heap<>((Comparator<Integer>) Comparator.naturalOrder().reversed());
+                        expected.add(20);
+                        expected.add(10);
+                        expected.add(15);
+                        expected.add(10);
+                        expected.add(5);
+                        classUnderTest.remove();
+                        assertThat(classUnderTest).isEqualTo(expected);
+                    }
+
+                    @Test
+                    void peek_many_returnsElement() {
+                        assertThat(classUnderTest.peek()).isEqualTo(20);
+                    }
+
+                    @Test
+                    void peek_many_unchanged() {
+                        classUnderTest.peek();
+                        assertThat(classUnderTest).isEqualTo(preState);
+                    }
+
+                    @Test
+                    void size_many_returnsSize() {
+                        assertThat(classUnderTest.size()).isEqualTo(6);
+                    }
+
+                    @Test
+                    void isEmpty_many_returnsFalse() {
+                        assertThat(classUnderTest.isEmpty()).isFalse();
+                    }
+
+                    @Test
+                    void toString_many_returnsString() {
+                        assertThat(classUnderTest.toString()).isEqualTo("[20, 10, 20, 10, 5, 15]");
+                    }
                 }
             }
         }

--- a/src/test/java/HeapTest.java
+++ b/src/test/java/HeapTest.java
@@ -2,8 +2,13 @@ import com.google.common.testing.EqualsTester;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.util.Comparator;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 class HeapTest {
 
@@ -99,6 +104,60 @@ class HeapTest {
     @Nested
     class WhenEmpty {
 
+        @Test
+        void add_empty_returnsTrue() {
+            assertThat(classUnderTest.add(20)).isTrue();
+        }
 
+        @Test
+        void remove_empty_throwsNoSuchElementException() {
+            assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(classUnderTest::remove);
+        }
+
+        @Test
+        void peek_empty_throwsNoSuchElementException() {
+            assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(classUnderTest::peek);
+        }
+
+        @Test
+        void size_empty_returnsZero() {
+            assertThat(classUnderTest.size()).isEqualTo(0);
+        }
+
+        @Test
+        void isEmpty_empty_returnsTrue() {
+            assertThat(classUnderTest.isEmpty()).isTrue();
+        }
+
+        @Nested
+        class WhenSingleton {
+
+            @BeforeEach
+            void addSingleton() {
+                classUnderTest.add(10);
+                preState.add(10);
+            }
+
+            @Nested
+            @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+            class WhenMany {
+
+                @BeforeEach
+                void addMany() {
+                    classUnderTest.add(20);
+                    classUnderTest.add(20);
+                    classUnderTest.add(10);
+                    classUnderTest.add(5);
+                    classUnderTest.add(15);
+                    preState.add(20);
+                    preState.add(20);
+                    preState.add(10);
+                    preState.add(5);
+                    preState.add(15);
+                }
+
+
+            }
+        }
     }
 }

--- a/src/test/java/HeapTest.java
+++ b/src/test/java/HeapTest.java
@@ -173,7 +173,7 @@ class HeapTest {
             }
 
             @Test
-            void size_singleton_returnsSzie() {
+            void size_singleton_returnsSize() {
                 assertThat(classUnderTest.size()).isEqualTo(1);
             }
 
@@ -205,7 +205,53 @@ class HeapTest {
                     preState.add(15);
                 }
 
+                @Test
+                void add_many_returnsTrue() {
+                    assertThat(classUnderTest.add(99)).isTrue();
+                }
 
+                @Test
+                void remove_many_returnsElement() {
+                    assertThat(classUnderTest.remove()).isEqualTo(5);
+                }
+
+                @Test
+                void remove_many_change() {
+                    Heap<Integer> expected = new Heap<>();
+                    expected.add(10);
+                    expected.add(10);
+                    expected.add(15);
+                    expected.add(20);
+                    expected.add(20);
+                    classUnderTest.remove();
+                    assertThat(classUnderTest).isEqualTo(expected);
+                }
+
+                @Test
+                void peek_many_returnsElement() {
+                    assertThat(classUnderTest.peek()).isEqualTo(5);
+                }
+
+                @Test
+                void peek_many_unchanged() {
+                    classUnderTest.peek();
+                    assertThat(classUnderTest).isEqualTo(preState);
+                }
+
+                @Test
+                void size_many_returnsSize() {
+                    assertThat(classUnderTest.size()).isEqualTo(6);
+                }
+
+                @Test
+                void isEmpty_many_returnsFalse() {
+                    assertThat(classUnderTest.isEmpty()).isFalse();
+                }
+
+                @Test
+                void toString_many_returnsString() {
+                    assertThat(classUnderTest.toString()).isEqualTo("[5, 10, 15, 20, 10, 20]");
+                }
             }
         }
     }


### PR DESCRIPTION
### Related Issues or PRs
#35, #34, #28, #15, #14, #13, #12


### What
Create a heap class that either:
- Uses the natural order of the elements being added
- Uses a provided Comparator to define the ordering 

### Testing
:+1:

Note that there is only a singlet test for trying to use a heap of non comparable types with no comparator provided at construction. I suppose I could do a full suite of tests, but it felt overkill. 

### Additional Notes
- This implementation does not have a definition of how it should operate if the type in the heap have no way to be compared to one another. If this happens, when comparing is attempted within the heap class, a `ClassCastException` will be thrown. This is the same thing that happens with Java's `PriorityQueue` class. This was done since (a) it's consistent with Java's existing implementation, (b) it's easier to deal with, and (b.5) I expect any sophisticated way to address this would over complicate things for the students.

- An equals method was implemented mostly for the purpose of testing the class. The definition of equality used was that the heaps' array's contents must match exactly. However, there is an argument that it should be equal if the elements would be removed in the same order, regardless of the order in the underlying array. When referring to Java's `PriorityQueue` class, which is just a heap, there is no equality defined. 


